### PR TITLE
bld: decouple optional deps and gate examples/tests on availability

### DIFF
--- a/CppCore/meson.build
+++ b/CppCore/meson.build
@@ -50,15 +50,30 @@ if rpc_enabled
 endif
 
 # ------------------------ Examples
+# Each example only builds when its required dependencies are present.
 
 if get_option('with_examples') and not get_option('with_rpc_client_only')
-    example_array = [  #
-        ['EigenCallLJPot', 'ljpot_call_eig', 'eigen_call_ljpot.cc', ''],
-        ['EigenCallCuH2Pot', 'cuh2_call_eig', 'eigen_call_cuh2.cc', ''],
-        ['XtCallCuH2Pot', 'cuh2_call_xt', 'xt_call_cuh2.cc', ''],
-        ['CallCuH2Pot', 'cuh2_call', 'call_cuh2.cc', ''],
-    ]
-    # Not really a test but the best way to make tiny programs
+    example_array = []
+    if has_fortran
+        example_array += [
+            ['CallCuH2Pot', 'cuh2_call', 'call_cuh2.cc', ''],
+        ]
+    endif
+    if has_eigen
+        example_array += [
+            ['EigenCallLJPot', 'ljpot_call_eig', 'eigen_call_ljpot.cc', ''],
+        ]
+        if has_fortran
+            example_array += [
+                ['EigenCallCuH2Pot', 'cuh2_call_eig', 'eigen_call_cuh2.cc', ''],
+            ]
+        endif
+    endif
+    if has_xtensor and has_fortran
+        example_array += [
+            ['XtCallCuH2Pot', 'cuh2_call_xt', 'xt_call_cuh2.cc', ''],
+        ]
+    endif
     foreach example : example_array
         test(
             example.get(0),
@@ -85,13 +100,16 @@ if get_option('with_tests')
     )
     test_args = _args
     test_args += ['-DRGPOTTEST']
-    test_array = [  #
-        # ['CuH2 Utils Test', 'cuh2_util_test', 'cuh2UtilsTest.cc', ''],
-]
+    test_array = []
     if has_fortran
-        test_array += [  #
+        test_array += [
             ['CuH2test', 'cuh2_test', 'CuH2PotTest.cc', ''],
         ]
+        if has_xtensor
+            test_array += [
+                ['CuH2 Utils Test', 'cuh2_util_test', 'cuh2UtilsTest.cc', ''],
+            ]
+        endif
     endif
     if get_option('with_cache')
         test_array += [  #

--- a/meson.build
+++ b/meson.build
@@ -55,50 +55,40 @@ if host_system != 'windows'
     _deps += [declare_dependency(link_args: '-lstdc++')]
 endif
 
-if get_option('with_examples') and not get_option('with_rpc_client_only')
-    # Eigen
-    if not get_option('with_eigen')
-        eigen_dep = dependency('eigen3')
-        if not eigen_dep.found()
-            eigen_dep = dependency(
-                'eigen3',
-                subproject: subproject('eigen'),
-                required: true,
-            )
-        endif
-        _deps += eigen_dep
+# --------------------- Optional dependencies
+# Each dependency is controlled by a single flag; examples select
+# themselves based on which deps are available (see CppCore/meson.build).
+
+has_eigen = false
+if get_option('with_eigen') or (get_option('with_examples') and not get_option('with_rpc_client_only'))
+    eigen_dep = dependency('eigen3', required: false)
+    if not eigen_dep.found()
+        eigen_dep = dependency(
+            'eigen3',
+            subproject: subproject('eigen'),
+            required: get_option('with_eigen'),
+        )
     endif
-    # fmt
-    fmt_dep = dependency('fmt', required: true)
-    _deps += fmt_dep
-    if not get_option('with_xtensor')
-        # These are added if not done later
-        _deps += dependency('xtensor')
-        _deps += dependency('xtensor-blas')
-        _args += ['-DWITH_XTENSOR=TRUE']
+    if eigen_dep.found()
+        _deps += eigen_dep
+        has_eigen = true
     endif
 endif
 
+has_xtensor = false
 if get_option('with_xtensor')
     _deps += dependency('xtensor')
     _deps += dependency('xtensor-blas')
     _args += ['-DWITH_XTENSOR=TRUE']
+    has_xtensor = true
 endif
 
-if get_option('with_eigen')
-    eigen_dep = dependency('eigen3')
-    if not eigen_dep.found()
-        eigen_dep = dependency('eigen3', subproject: subproject('eigen'))
-    endif
-    _deps += eigen_dep
-endif
-
-
-if not get_option('pure_lib')
+has_fmt = false
+if not get_option('pure_lib') or (get_option('with_examples') and not get_option('with_rpc_client_only'))
     _args += ['-DNOT_PURE_LIB=TRUE']
-    subproject('fmt')
     fmt_dep = dependency('fmt', required: true)
     _deps += fmt_dep
+    has_fmt = true
 endif
 
 # --------------------- Subprojects


### PR DESCRIPTION
The dependency resolution in meson.build had inverted logic where `with_examples` would unconditionally pull xtensor and eigen. Each optional dependency now has its own clean section with a boolean tracking variable (has_eigen, has_xtensor, has_fmt). Examples and tests in CppCore/meson.build select themselves based on which deps are actually present, and the previously disabled cuh2UtilsTest is re-enabled when has_fortran and has_xtensor are both available.

Closes #15