### PR TITLE
fix(rpc): full Windows/MSVC compatibility for capnp codegen and linking

### DIFF
--- a/CppCore/rgpot/rpc/capnp_compile.py
+++ b/CppCore/rgpot/rpc/capnp_compile.py
@@ -1,0 +1,21 @@
+"""Run capnp compile and rename .c++ output to .cpp for MSVC compatibility.
+
+Usage: python capnp_compile.py <capnp> <outdir> <src_prefix> <input>
+
+MSVC cl.exe does not recognise the .c++ extension that capnp emits.
+This wrapper renames the generated source so that all compilers can
+consume it without extra flags.
+"""
+import os
+import shutil
+import subprocess
+import sys
+
+capnp, outdir, src_prefix, schema = sys.argv[1:5]
+subprocess.check_call([capnp, "compile", f"-oc++:{outdir}", f"--src-prefix={src_prefix}", schema])
+
+base = os.path.splitext(os.path.basename(schema))[0]  # e.g. "Potentials"
+old = os.path.join(outdir, f"{base}.capnp.c++")
+new = os.path.join(outdir, f"{base}.capnp.cpp")
+if os.path.exists(old):
+    shutil.move(old, new)

--- a/CppCore/rgpot/rpc/meson.build
+++ b/CppCore/rgpot/rpc/meson.build
@@ -1,16 +1,18 @@
 # Find dependencies and tools
 capnp_rpc_dep = dependency('capnp-rpc')
-capnpc = find_program('capnpc')
+capnp = find_program('capnp')
+python = find_program('python3', 'python')
 
 gen_rpc = custom_target(
     'gen_rpc',
     input: 'Potentials.capnp',
-    output: ['Potentials.capnp.c++', 'Potentials.capnp.h'],
+    output: ['Potentials.capnp.cpp', 'Potentials.capnp.h'],
     command: [
-        capnpc,
-        '-o',
-        'c++:@OUTDIR@',
-        '--src-prefix=' + meson.current_source_dir(),
+        python,
+        meson.current_source_dir() / 'capnp_compile.py',
+        capnp,
+        '@OUTDIR@',
+        meson.current_source_dir(),
         '@INPUT@',
     ],
 )
@@ -26,10 +28,16 @@ ptlrpc = library(
     install: not meson.is_subproject(),
 )
 
+_ptlrpc_extra_deps = [capnp_rpc_dep]
+if host_machine.system() == 'windows'
+    _ptlrpc_extra_deps += cppc.find_library('ws2_32')
+endif
+
 ptlrpc_dep = declare_dependency(
     link_with: ptlrpc,
     sources: gen_rpc,
     include_directories: _incdirs,
+    dependencies: _ptlrpc_extra_deps,
 )
 
 pot_bridge = library(


### PR DESCRIPTION
Three issues fixed:
- capnpc.EXE on Windows does not support -o; use capnp compile instead
- MSVC cl.exe does not recognise .c++ extension; rename to .cpp
- kj-async needs ws2_32 on Windows; export via ptlrpc_dep