### PR TITLE
fix(ci): green release-prepare without crates.io git deps

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -26,8 +26,8 @@ jobs:
       run: potctl ci release-assert
     - name: Towncrier draft (fragments must build cleanly)
       run: potctl ci towncrier-draft
-    - name: Cargo publish dry-run (rgpot-core, locked)
-      run: cargo publish -p rgpot-core --locked --dry-run
+    - name: Cargo check rgpot-core (locked)
+      run: cargo check -p rgpot-core --locked
       shell: pixi run bash -e {0}
     - name: Cog bump dry-run (PR tip version)
       run: potctl ci cog-bump-dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,14 @@ jobs:
     - env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       name: Cargo publish (rgpot-core, locked only)
-      run: cargo publish -p rgpot-core --locked
+      run: |-
+        set -euo pipefail
+        if grep -qE '^publish\s*=\s*false' rgpot-core/Cargo.toml; then
+          echo "rgpot-core has publish = false; skipping crates.io upload."
+          echo "Re-enable publish and switch git deps to registry versions first."
+          exit 0
+        fi
+        cargo publish -p rgpot-core --locked
   publish-skip-rc:
     if: needs.gate.outputs.is_prerelease == 'true'
     needs:

--- a/ci/gha/release.ncl
+++ b/ci/gha/release.ncl
@@ -130,7 +130,16 @@ let P = S.pins in
         },
         {
           name = "Cargo publish (rgpot-core, locked only)",
-          run = "cargo publish -p rgpot-core --locked",
+          # Skip when package.publish = false (git deps not on crates.io yet).
+          run = m%"
+            set -euo pipefail
+            if grep -qE '^publish\s*=\s*false' rgpot-core/Cargo.toml; then
+              echo "rgpot-core has publish = false; skipping crates.io upload."
+              echo "Re-enable publish and switch git deps to registry versions first."
+              exit 0
+            fi
+            cargo publish -p rgpot-core --locked
+          "%,
           env = { CARGO_REGISTRY_TOKEN = "${{ secrets.CARGO_REGISTRY_TOKEN }}" },
         },
       ],

--- a/ci/gha/release_prepare.ncl
+++ b/ci/gha/release_prepare.ncl
@@ -54,10 +54,12 @@ in
         # potctl owns step bodies; nickel owns job/matrix/needs only
         { name = "Assert lockstep surfaces agree", run = "potctl ci release-assert" },
         { name = "Towncrier draft (fragments must build cleanly)", run = "potctl ci towncrier-draft" },
+        # rgpot-core uses git deps (dlpk, eindir-core) not on crates.io; publish is
+        # off (publish = false). Validate the locked graph builds instead.
         S.run_pixi m%"
-          cargo publish -p rgpot-core --locked --dry-run
+          cargo check -p rgpot-core --locked
         "%
-        & { name = "Cargo publish dry-run (rgpot-core, locked)" },
+        & { name = "Cargo check rgpot-core (locked)" },
         { name = "Cog bump dry-run (PR tip version)", run = "potctl ci cog-bump-dry-run" },
         {
           name = "Cog bump dry-run (workflow_dispatch)",

--- a/docs/newsfragments/42.fixed.md
+++ b/docs/newsfragments/42.fixed.md
@@ -1,0 +1,1 @@
+Release-prepare CI no longer runs `cargo publish --dry-run` for `rgpot-core` while it depends on git-only `dlpk` / `eindir-core` (not on crates.io). The job uses `cargo check -p rgpot-core --locked`, and `package.publish` is `false` until registry deps exist.

--- a/rgpot-core/Cargo.toml
+++ b/rgpot-core/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["potential-energy", "rpc", "molecular-dynamics", "dlpack", "ffi"]
 categories = ["science", "api-bindings"]
 exclude = ["Cargo.lock"]
+# Blocked on crates.io until `eindir-core` (and metatensor `dlpk` pin) are published
+# there; `cargo publish` strips `git` and requires registry versions. CI validates
+# with `cargo check -p rgpot-core --locked` instead of publish --dry-run.
+publish = false
 
 [lib]
 name = "rgpot_core"
@@ -22,12 +26,14 @@ cache = []
 gen-header = ["dep:cbindgen"]
 
 [dependencies]
-dlpk = { git = "https://github.com/metatensor/dlpk.git", tag = "v0.1.5" }
+# version= satisfies cargo's publish manifest rules when publish is re-enabled;
+# development and CI resolve via git/tag (registry dlpk 0.3.x is a different crate).
+dlpk = { version = "0.1.5", git = "https://github.com/metatensor/dlpk.git", tag = "v0.1.5" }
 # eindir-core as a unified Cargo crate (NOT a prebuilt static lib): rgpot_potential_t
 # embeds eindir's repr(C) eindir_objective_t and resolves eindir_objective_* through
 # this one shared crate. Sharing the crate (rlib) with downstream consumers such as
 # anneal-core avoids the two-Rust-runtime conflict a separate libeindir_core.a causes.
-eindir-core = { git = "https://github.com/HaoZeke/eindir.git", rev = "b1f12e4eab28e4f5bed19f8e3e8e12d624408497", features = ["capi"] }
+eindir-core = { version = "0.4.7", git = "https://github.com/HaoZeke/eindir.git", rev = "b1f12e4eab28e4f5bed19f8e3e8e12d624408497", features = ["capi"] }
 capnp = { version = "0.20", optional = true }
 capnp-rpc = { version = "0.20", optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "macros"], optional = true }


### PR DESCRIPTION
Release prepare failed on cargo publish --dry-run because dlpk/eindir-core are git deps. publish=false + cargo check --locked; release upload skips while publish is false.