### PR TITLE
fix(cpp): MSVC compatibility for cxxabi and box memcpy

### DIFF
--- a/CppCore/rgpot/Potential.hpp
+++ b/CppCore/rgpot/Potential.hpp
@@ -11,6 +11,7 @@
  */
 
 // clang-format off
+#include <array>
 #include <cstring>
 #include <utility>
 #include <vector>
@@ -129,7 +130,9 @@ public:
 
     double flatBox[9];
     static_assert(sizeof(box) == 9 * sizeof(double));
-    std::memcpy(flatBox, &box[0][0], sizeof(flatBox));
+    // Nested std::array is contiguous; &box[0][0] is invalid on MSVC (C2676)
+    // and box.data() can hit incomplete-type issues depending on include order.
+    std::memcpy(flatBox, static_cast<const void *>(&box), sizeof(flatBox));
 
     ForceInput fi{.nAtoms = nAtoms,
                   .pos = positions.data(),

--- a/CppCore/rgpot/base_types.hpp
+++ b/CppCore/rgpot/base_types.hpp
@@ -10,10 +10,6 @@
 // MIT License
 // Copyright 2023--present rgpot developers
 
-// clang-format off
-#include <cxxabi.h>
-// clang-format on
-
 #include <algorithm>
 #include <any>
 #include <cctype>

--- a/CppCore/rgpot/types/AtomMatrix.hpp
+++ b/CppCore/rgpot/types/AtomMatrix.hpp
@@ -9,10 +9,6 @@
  * atomic coordinates and forces.
  */
 
-// clang-format off
-#include <cxxabi.h>
-// clang-format on
-
 #include <algorithm>
 #include <iomanip>
 #include <iostream>

--- a/docs/newsfragments/+msvc-windows.fixed.md
+++ b/docs/newsfragments/+msvc-windows.fixed.md
@@ -1,0 +1,2 @@
+Windows/MSVC builds no longer fail on unused ``cxxabi.h`` includes or nested
+``std::array`` box flattening in ``Potential`` (``C1083`` / ``C2676``).


### PR DESCRIPTION
## Summary

- Remove unused `<cxxabi.h>` includes from `base_types.hpp` and `AtomMatrix.hpp` (MSVC has no such header; breaks with C1083).
- In `Potential.hpp`, include `<array>` and flatten the nested `std::array` simulation box via `memcpy` from the object address instead of `&box[0][0]` (MSVC C2676 / incomplete-type issues).

These are the same fixes currently carried as conda-forge patches on eon-feedstock so Windows builds can enable rgpot without out-of-tree patches.

## Test plan

- [ ] CI green on this PR (orchestrator / platform matrix)
- [ ] Towncrier check accepts `docs/newsfragments/+msvc-windows.fixed.md`
- [ ] After merge: cut patch release and drop feedstock patches on conda-forge/eon-feedstock