### PR TITLE
chore(release): prepare v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.2.1](https://github.com/OmniPotentRPC/rgpot/tree/2.2.1) - 2026-07-06
+
+### Fixed
+
+- Windows/MSVC builds no longer fail on unused ``cxxabi.h`` includes or nested
+  ``std::array`` box flattening in ``Potential`` (``C1083`` / ``C2676``).
+
+
 ## [2.2.0](https://github.com/OmniPotentRPC/rgpot/tree/2.2.0) - 2026-07-05
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   rgpot
-  VERSION 2.2.0
+  VERSION 2.2.1
   DESCRIPTION "Cpp core for potential energy surface functionality"
   HOMEPAGE_URL "https://github.com/OmniPotentRPC/rgpot"
   LANGUAGES C CXX)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rgpot-core"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/docs/newsfragments/+msvc-windows.fixed.md
+++ b/docs/newsfragments/+msvc-windows.fixed.md
@@ -1,2 +1,0 @@
-Windows/MSVC builds no longer fail on unused ``cxxabi.h`` includes or nested
-``std::array`` box flattening in ``Potential`` (``C1083`` / ``C2676``).

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'rgpot',
     'cpp',
-    version: '2.2.0',
+    version: '2.2.1',
     default_options: ['warning_level=2', 'cpp_std=c++20'],
 )
 # IMPORTANT!! warning_level=3 passes -fimplicit-none

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "RPC based core for potential energy surface functionality."
 name = "rgpot"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "2.2.0"
+version = "2.2.1"
 
 [feature.cigen.tasks]
 # Export every ci/gha/*.ncl workflow (shared pins/steps in ci/gha/lib/).

--- a/rgpot-core/Cargo.toml
+++ b/rgpot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgpot-core"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 description = "Core Rust library for rgpot: RPC-based potential energy surface calculations"
 license = "MIT"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 name = "rgpot"
-version = "2.2.0"
+version = "2.2.1"
 directory = "docs/newsfragments"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
## Summary

Patch release after #45 (MSVC header / box flatten fixes).

- Lockstep surfaces → **2.2.1**
- Towncrier: MSVC Windows fix fragment folded into CHANGELOG
- After merge: tag `v2.2.1` to run release.yml (GH Release + crates.io)

## Test plan

- [ ] release-prepare / CI green
- [ ] merge to main
- [ ] push annotated tag `v2.2.1`