### PR TITLE
release: v2.5.2 vesin 0.6 VesinOptions ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.5.2](https://github.com/OmniPotentRPC/rgpot/tree/2.5.2) - 2026-07-18
+
+### Fixed
+
+- Rebuild Metatomic engines against vesin 0.6+ ``VesinOptions`` (``skin`` /
+  ``n_threads``) so ``vesin_neighbors`` no longer fails with a bare error when
+  runtime libvesin is 0.6 and the engine was built for 0.5.
+
+
 ## [2.5.0](https://github.com/OmniPotentRPC/rgpot/tree/2.5.0) - 2026-07-17
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   rgpot
-  VERSION 2.5.0
+  VERSION 2.5.2
   DESCRIPTION "Cpp core for potential energy surface functionality"
   HOMEPAGE_URL "https://github.com/OmniPotentRPC/rgpot"
   LANGUAGES C CXX)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rgpot-core"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/CppCore/rgpot/MetatomicPot/MetatomicPot.cc
+++ b/CppCore/rgpot/MetatomicPot/MetatomicPot.cc
@@ -457,17 +457,11 @@ metatensor_torch::TensorBlock MetatomicPot::computeNeighbors(
 
   auto cutoff = request->engine_cutoff(m_config.length_unit);
 
-  // Zero-init VesinOptions so unknown/newer fields stay at safe defaults.
-  // algorithm (vesin 0.5+) is set via type-trait helper so older headers
-  // without that member still compile — never names VesinAutoAlgorithm.
+  // VesinOptions layout must match the linked libvesin (0.5 vs 0.6 diverge
+  // on skin/n_threads). fill_neighbor_options zero-inits and sets fields
+  // via vesin_compat traits for the headers we compile against.
   VesinOptions options{};
-  options.cutoff = cutoff;
-  options.full = request->full_list();
-  options.sorted = false;
-  vesin_compat::set_algorithm_default(options);
-  options.return_shifts = true;
-  options.return_distances = false;
-  options.return_vectors = true;
+  vesin_compat::fill_neighbor_options(options, cutoff, request->full_list());
 
   VesinNeighborList *vesin_nl = new VesinNeighborList();
 
@@ -483,7 +477,16 @@ metatensor_torch::TensorBlock MetatomicPot::computeNeighbors(
     std::string err_str = "vesin_neighbors failed";
     if (error_message != nullptr) {
       err_str += ": " + std::string(error_message);
+    } else {
+      // Bare failure is the usual symptom of a VesinOptions ABI mismatch
+      // (engine built against a different vesin minor than libvesin.so).
+      err_str +=
+          " (no message; check vesin header/lib major match — need "
+          "vesin>=0.6 for current engines)";
     }
+    err_str += " cutoff=" + std::to_string(cutoff) +
+               " nAtoms=" + std::to_string(nAtoms) +
+               " full=" + std::to_string(static_cast<int>(options.full));
     delete vesin_nl;
     throw std::runtime_error(err_str);
   }

--- a/CppCore/rgpot/MetatomicPot/vesin_compat.hpp
+++ b/CppCore/rgpot/MetatomicPot/vesin_compat.hpp
@@ -2,11 +2,21 @@
 // MIT License
 // Copyright 2023--present rgpot developers
 //
-// Source-level compatibility for vesin 0.3.x (enum VesinDevice, no
-// Options.algorithm) and vesin 0.5+ (struct VesinDevice {type, device_id},
-// Options.algorithm). Detection is pure C++ type traits — no parent-build
-// macros (RGPOT_VESIN_*) required.
+// Source-level compatibility for vesin neighbor options across:
+//   0.3.x  — enum VesinDevice, no Options.algorithm
+//   0.5.x  — struct VesinDevice {type, device_id}, Options.algorithm
+//   0.6.x  — Options.skin + Options.n_threads inserted before return_* flags
+//
+// Detection is pure C++ type traits — no parent-build macros required.
+//
+// IMPORTANT: VesinOptions is passed by value into vesin_neighbors. The
+// compile-time header layout MUST match the runtime libvesin.so. Building
+// against 0.5 and loading 0.6 (or the reverse) shifts return_shifts /
+// return_vectors into the skin/n_threads slots and fails with a bare
+// "vesin_neighbors failed" (no error_message). Pin build and runtime vesin
+// to the same major line (see pyproject / pixi.toml).
 
+#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -46,6 +56,24 @@ struct has_algorithm_member<
     Options, std::void_t<decltype(std::declval<Options>().algorithm)>>
     : std::true_type {};
 
+// vesin 0.6+: Verlet skin (0 disables caching).
+template <typename Options, typename = void>
+struct has_skin_member : std::false_type {};
+
+template <typename Options>
+struct has_skin_member<Options,
+                       std::void_t<decltype(std::declval<Options>().skin)>>
+    : std::true_type {};
+
+// vesin 0.6+: explicit thread count (0 = OMP_NUM_THREADS / hardware).
+template <typename Options, typename = void>
+struct has_n_threads_member : std::false_type {};
+
+template <typename Options>
+struct has_n_threads_member<
+    Options, std::void_t<decltype(std::declval<Options>().n_threads)>>
+    : std::true_type {};
+
 // When algorithm exists, assign its zero/default value without naming
 // VesinAutoAlgorithm (absent from older headers). No-op otherwise.
 template <typename Options>
@@ -53,6 +81,37 @@ void set_algorithm_default(Options &options) {
   if constexpr (has_algorithm_member<Options>::value) {
     options.algorithm = {};
   }
+}
+
+template <typename Options>
+void set_skin(Options &options, double skin) {
+  if constexpr (has_skin_member<Options>::value) {
+    options.skin = skin;
+  }
+}
+
+template <typename Options>
+void set_n_threads(Options &options, std::int32_t n_threads) {
+  if constexpr (has_n_threads_member<Options>::value) {
+    options.n_threads = n_threads;
+  }
+}
+
+// Fill shared VesinOptions fields for a neighbor request. Zero-init the
+// struct first so unknown/newer members stay at safe defaults.
+template <typename Options>
+void fill_neighbor_options(Options &options, double cutoff, bool full_list) {
+  options = Options{};
+  options.cutoff = cutoff;
+  options.full = full_list;
+  options.sorted = false;
+  set_algorithm_default(options);
+  // 0.6+: no Verlet cache; auto thread count.
+  set_skin(options, 0.0);
+  set_n_threads(options, 0);
+  options.return_shifts = true;
+  options.return_distances = false;
+  options.return_vectors = true;
 }
 
 } // namespace vesin_compat

--- a/CppCore/tests/MetatomicPotTest.cc
+++ b/CppCore/tests/MetatomicPotTest.cc
@@ -194,6 +194,48 @@ TEST_CASE("vesin_compat traits distinguish enum vs struct device layouts",
   rgpot::vesin_compat::set_algorithm_default(without_alg);
   REQUIRE_THAT(without_alg.cutoff, WithinAbs(3.5, 1e-15));
 
+  // vesin 0.6 skin / n_threads members (and absence on older shapes).
+  struct OptionsWithSkinThreads {
+    double skin = -1.0;
+    int n_threads = -1;
+  };
+  struct OptionsNoSkin {
+    double cutoff = 0.0;
+  };
+  STATIC_REQUIRE(
+      rgpot::vesin_compat::has_skin_member<OptionsWithSkinThreads>::value);
+  STATIC_REQUIRE(
+      rgpot::vesin_compat::has_n_threads_member<OptionsWithSkinThreads>::value);
+  STATIC_REQUIRE_FALSE(
+      rgpot::vesin_compat::has_skin_member<OptionsNoSkin>::value);
+
+  OptionsWithSkinThreads with_skin{};
+  rgpot::vesin_compat::set_skin(with_skin, 0.25);
+  rgpot::vesin_compat::set_n_threads(with_skin, 4);
+  REQUIRE_THAT(with_skin.skin, WithinAbs(0.25, 1e-15));
+  REQUIRE(with_skin.n_threads == 4);
+
+  // Live VesinOptions from the build's vesin.h: fill_neighbor_options must
+  // produce a usable request (and set 0.6 fields when present).
+  {
+    VesinOptions live{};
+    rgpot::vesin_compat::fill_neighbor_options(live, /*cutoff=*/5.0,
+                                               /*full_list=*/true);
+    REQUIRE_THAT(live.cutoff, WithinAbs(5.0, 1e-15));
+    REQUIRE(live.full);
+    REQUIRE_FALSE(live.sorted);
+    REQUIRE(live.return_shifts);
+    REQUIRE_FALSE(live.return_distances);
+    REQUIRE(live.return_vectors);
+    if constexpr (rgpot::vesin_compat::has_skin_member<VesinOptions>::value) {
+      REQUIRE_THAT(live.skin, WithinAbs(0.0, 1e-15));
+    }
+    if constexpr (rgpot::vesin_compat::has_n_threads_member<
+                      VesinOptions>::value) {
+      REQUIRE(live.n_threads == 0);
+    }
+  }
+
   // Live VesinDevice from the build's vesin.h must construct without error.
   // Branch via a function template so if constexpr can discard the inactive
   // arm (plain if constexpr in this non-template TEST_CASE type-checks both).

--- a/docs/newsfragments/+vesin06-options.fixed.md
+++ b/docs/newsfragments/+vesin06-options.fixed.md
@@ -1,3 +1,0 @@
-Rebuild Metatomic engines against vesin 0.6+ ``VesinOptions`` (``skin`` /
-``n_threads``) so ``vesin_neighbors`` no longer fails with a bare error when
-runtime libvesin is 0.6 and the engine was built for 0.5.

--- a/docs/newsfragments/+vesin06-options.fixed.md
+++ b/docs/newsfragments/+vesin06-options.fixed.md
@@ -1,0 +1,3 @@
+Rebuild Metatomic engines against vesin 0.6+ ``VesinOptions`` (``skin`` /
+``n_threads``) so ``vesin_neighbors`` no longer fails with a bare error when
+runtime libvesin is 0.6 and the engine was built for 0.5.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'rgpot',
     'cpp',
-    version: '2.5.0',
+    version: '2.5.2',
     default_options: ['warning_level=2', 'cpp_std=c++20'],
 )
 # IMPORTANT!! warning_level=3 passes -fimplicit-none

--- a/pixi.lock
+++ b/pixi.lock
@@ -1542,7 +1542,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/23/0c/3d0e1db6b741087ed23a0790446ea8a0ec806f3b8233ea9492cb3c847fbe/vesin-0.5.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/26/c8/8c69982b64b4672b3264518abe3fd5dc18184a7eea2eed63289c0540b6ab/vesin_torch-0.6.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl
@@ -1550,12 +1550,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/e6/60691e210a43b738249ee9abb3f2343dece72d0b821fda3d4023e061d26a/metatensor_operations-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/d1/2ca1ec1cbd728e29a0754b2fee177eb10f1b9840f5f62940a3c4085b6672/vesin-0.6.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9c/17/49fc50b531fd0a2e094407a0add8dc25f685d2740fd3162ef4ea0d21c627/metatomic_torch-0.1.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a1/bc/6911ec3126812499ae9c3ae8cf1e9d6f1b4da237c1d507ddc34385fe6b24/vesin_torch-0.5.3-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl
@@ -18828,19 +18828,18 @@ packages:
   requires_dist:
   - nvidia-nvjitlink-cu12
   requires_python: '>=3'
-- pypi: https://files.pythonhosted.org/packages/23/0c/3d0e1db6b741087ed23a0790446ea8a0ec806f3b8233ea9492cb3c847fbe/vesin-0.5.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: vesin
-  version: 0.5.3
-  sha256: 5993282c9f9dd6ddda31804d3d673027e79a7678bb4e5022edc771bb0a813c6d
-  requires_dist:
-  - numpy
-  - vesin-torch ; extra == 'torch'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
   name: opt-einsum
   version: 3.4.0
   sha256: 69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/26/c8/8c69982b64b4672b3264518abe3fd5dc18184a7eea2eed63289c0540b6ab/vesin_torch-0.6.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: vesin-torch
+  version: 0.6.0
+  sha256: 709c6ff6665880a74e76b2e3d2d2638c6fb61e43a034ebc5d200fda6cc00d050
+  requires_dist:
+  - torch>=2.3,<2.14
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/37/ae/06d7dfc5633c7250fefc61fd624990aa2c37e3495c08a2f23968b1acb23e/shibuya-2026.1.9-py3-none-any.whl
   name: shibuya
   version: 2026.1.9
@@ -18991,6 +18990,14 @@ packages:
   version: 2.27.5
   sha256: ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/75/d1/2ca1ec1cbd728e29a0754b2fee177eb10f1b9840f5f62940a3c4085b6672/vesin-0.6.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: vesin
+  version: 0.6.0
+  sha256: 166b6bb2ecb8178387d412b4ac6120d0ac5f6c7e2fc055be0e0456010d9e5dbb
+  requires_dist:
+  - numpy
+  - vesin-torch ; extra == 'torch'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cusolver-cu12
   version: 11.7.3.90
@@ -19156,13 +19163,6 @@ packages:
   - pytest-mpl ; extra == 'test-extras'
   - pytest-randomly ; extra == 'test-extras'
   requires_python: '>=3.11,!=3.14.1'
-- pypi: https://files.pythonhosted.org/packages/a1/bc/6911ec3126812499ae9c3ae8cf1e9d6f1b4da237c1d507ddc34385fe6b24/vesin_torch-0.5.3-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-  name: vesin-torch
-  version: 0.5.3
-  sha256: b9e36b74c99ccaa0da13afc59853da296c0df9e85066bc8ade94e7ef8bec46cb
-  requires_dist:
-  - torch>=2.3,<2.11
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
   name: sympy
   version: 1.14.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "RPC based core for potential energy surface functionality."
 name = "rgpot"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "2.5.0"
+version = "2.5.2"
 
 [feature.cigen.tasks]
 # Export every ci/gha/*.ncl workflow (shared pins/steps in ci/gha/lib/).

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,8 +46,10 @@ platforms = ["linux-64"]
 torch = ">=2.10, <2.11"
 metatomic-torch = ">=0.1.9, <0.2"
 metatensor-torch = ">=0.8.4, <0.9"
-vesin-torch = ">=0.5.2, <0.6"
-vesin = ">=0.5.2, <0.6"
+# vesin 0.6 inserts skin/n_threads into VesinOptions; engines must build and
+# run against the same line (ABI is pass-by-value).
+vesin-torch = ">=0.6.0, <0.7"
+vesin = ">=0.6.0, <0.7"
 
 [feature.rpc.dependencies]
 capnproto = ">=1.0.2,<2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rgpot"
-version = "2.5.0"
+version = "2.5.2"
 description = "Potential energy surfaces for atomistic simulation (LJ + Metatomic multi-ABI dlopen; nanobind abi3)"
 readme = "README.md"
 license = { text = "MIT" }
@@ -39,7 +39,8 @@ metatomic = [
   "metatensor-core>=0.1.0",
   "metatensor-torch>=0.6.0",
   "metatomic-torch>=0.1.0",
-  "vesin>=0.1.0",
+  # 0.6+ VesinOptions (skin/n_threads); must match engine build headers.
+  "vesin>=0.6.0",
 ]
 ase = ["ase>=3.22"]
 test = ["pytest>=7", "numpy>=1.24"]
@@ -57,7 +58,7 @@ requires = [
   "metatensor-core",
   "metatensor-torch",
   "metatomic-torch",
-  "vesin",
+  "vesin>=0.6.0",
 ]
 build-backend = "mesonpy"
 

--- a/python/bind/bind_module.cpp
+++ b/python/bind/bind_module.cpp
@@ -143,7 +143,7 @@ NB_MODULE(_core, m) {
   m.doc() =
       "rgpot Python bindings (nanobind): LJ core + Metatomic dlopen frontend. "
       "Stable ABI (abi3) when built with Python >= 3.12.";
-  m.attr("__version__") = "2.4.0";
+  m.attr("__version__") = "2.5.2";
   m.attr("has_metatomic_dlopen") = true;
 
   m.def("evaluate_lj", &evaluate_lj, nb::arg("positions"),

--- a/rgpot-core/Cargo.toml
+++ b/rgpot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgpot-core"
-version = "2.5.0"
+version = "2.5.2"
 edition = "2021"
 description = "Core Rust library for rgpot: RPC-based potential energy surface calculations"
 license = "MIT"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 name = "rgpot"
-version = "2.5.0"
+version = "2.5.2"
 directory = "docs/newsfragments"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
## Summary
- Rebuild Metatomic engines for vesin 0.6 ``VesinOptions`` (``skin`` / ``n_threads``).
- Lockstep version surfaces and CHANGELOG for **2.5.2**.
- Annotated tag ``v2.5.2`` already pushed (tag-triggered ``release.yml``).

## Test plan
- [x] ``potctl release assert --require-changelog 2.5.2``
- [ ] CI gate on this PR
- [ ] Multi-ABI Python wheel upload after merge