### PR TITLE
release: v2.5.3 client-only unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.5.3](https://github.com/OmniPotentRPC/rgpot/tree/2.5.3) - 2026-07-20
+
+### Fixed
+
+- Fix ``-Dwith_rpc_client_only=true -Dwith_tests=true``: use ``pot_bridge_dep``
+  (was undefined ``rgpot_bridge_dep``), link ``units.cc`` into unit tests when
+  ``rgpot_core`` is not built, and soft-skip bridge stress cases when potserv is
+  not running (lazy client connect). Catch2 configure/link/test succeed for the
+  client frontend product without a live server.
+
+
 ## [2.5.2](https://github.com/OmniPotentRPC/rgpot/tree/2.5.2) - 2026-07-18
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   rgpot
-  VERSION 2.5.2
+  VERSION 2.5.3
   DESCRIPTION "Cpp core for potential energy surface functionality"
   HOMEPAGE_URL "https://github.com/OmniPotentRPC/rgpot"
   LANGUAGES C CXX)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rgpot-core"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/CppCore/meson.build
+++ b/CppCore/meson.build
@@ -153,6 +153,17 @@ if get_option('with_tests')
     )
     test_args = _args
     test_args += ['-DRGPOTTEST']
+    # Client-only builds skip rgpot_core; UnitsTest still needs units.cc.
+    if get_option('with_rpc_client_only')
+        units_for_tests = static_library(
+            'units_for_tests',
+            sources: ['rgpot/units.cc'],
+            include_directories: _incdirs,
+            cpp_args: _args,
+            install: false,
+        )
+        test_deps += declare_dependency(link_with: units_for_tests)
+    endif
     test_array = [
         ['UnitsTest', 'units_test', 'UnitsTest.cc', ''],
     ]
@@ -332,7 +343,7 @@ if get_option('with_tests')
         test_deps += ptlrpc_dep
         test_array += [['RPCTest', 'test_rpc', 'CapnpAdapterTest.cc', '']]
         if get_option('with_rpc_client_only')
-            test_deps += rgpot_bridge_dep
+            test_deps += pot_bridge_dep
             test_array += [
                 ['RPCClientTest', 'test_rpc_client', 'BridgeStressTest.cc', ''],
             ]

--- a/CppCore/tests/BridgeStressTest.cc
+++ b/CppCore/tests/BridgeStressTest.cc
@@ -92,6 +92,18 @@ TEST_CASE("Bridge Calculation Stress", "[bridge][perf]") {
   std::vector<double> forces(natoms * 3);
   double energy = 0;
 
+  // pot_client_init is lazy: connection only opens on first calculate.
+  // Without potserv (packaging/unit CI), skip rather than hard-fail.
+  {
+    int probe = pot_calculate(client, natoms, pos.data(), atmnrs.data(),
+                              box.data(), &energy, forces.data());
+    if (probe != 0) {
+      std::string err = pot_get_last_error(client);
+      pot_client_free(client);
+      SKIP("potserv not reachable at " << HOST << ":" << PORT << ": " << err);
+    }
+  }
+
   SECTION("Sequential Load (1000 calls)") {
     for (int i = 0; i < 1000; ++i) {
       int res = pot_calculate(client, natoms, pos.data(), atmnrs.data(),

--- a/docs/newsfragments/+client-only-tests.fixed.md
+++ b/docs/newsfragments/+client-only-tests.fixed.md
@@ -1,0 +1,5 @@
+Fix ``-Dwith_rpc_client_only=true -Dwith_tests=true``: use ``pot_bridge_dep``
+(was undefined ``rgpot_bridge_dep``), link ``units.cc`` into unit tests when
+``rgpot_core`` is not built, and soft-skip bridge stress cases when potserv is
+not running (lazy client connect). Catch2 configure/link/test succeed for the
+client frontend product without a live server.

--- a/docs/newsfragments/+client-only-tests.fixed.md
+++ b/docs/newsfragments/+client-only-tests.fixed.md
@@ -1,5 +1,0 @@
-Fix ``-Dwith_rpc_client_only=true -Dwith_tests=true``: use ``pot_bridge_dep``
-(was undefined ``rgpot_bridge_dep``), link ``units.cc`` into unit tests when
-``rgpot_core`` is not built, and soft-skip bridge stress cases when potserv is
-not running (lazy client connect). Catch2 configure/link/test succeed for the
-client frontend product without a live server.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'rgpot',
     'cpp',
-    version: '2.5.2',
+    version: '2.5.3',
     default_options: ['warning_level=2', 'cpp_std=c++20'],
 )
 # IMPORTANT!! warning_level=3 passes -fimplicit-none

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "RPC based core for potential energy surface functionality."
 name = "rgpot"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "2.5.2"
+version = "2.5.3"
 
 [feature.cigen.tasks]
 # Export every ci/gha/*.ncl workflow (shared pins/steps in ci/gha/lib/).

--- a/rgpot-core/Cargo.toml
+++ b/rgpot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgpot-core"
-version = "2.5.2"
+version = "2.5.3"
 edition = "2021"
 description = "Core Rust library for rgpot: RPC-based potential energy surface calculations"
 license = "MIT"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 name = "rgpot"
-version = "2.5.2"
+version = "2.5.3"
 directory = "docs/newsfragments"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
## Summary
- Fix client-only + with_tests configure/link (pot_bridge_dep, units.cc)
- Soft-skip bridge stress without potserv
- Version lockstep v2.5.3

## Test plan
- [x] meson client-only + tests: 5/5 OK on foss/GCCcore-15.2.0