### PR TITLE
fix(python): build the Fortran potentials into the wheel (v3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [3.0.1](https://github.com/OmniPotentRPC/rgpot/tree/3.0.1) - 2026-07-26
+
+### Fixed
+
+- The Python wheel builds the Fortran 2018 potentials. `[tool.meson-python.args]`
+  never passed `-Dwith_fortran_pots`, so a wheel carried a `librgpot` with no
+  Fortran-backed potential in it -- SW, EDIP, Lenosky, Tersoff, EAM-Al, FeHe,
+  CuH2, and TIP4P-H were all missing from the one artifact most users install.
+  The cibuildwheel configuration installs a Fortran compiler in the build
+  image to match, and the repair step vendors `libgfortran` as it would any
+  other dependency.
+
+
 ## [3.0.0](https://github.com/OmniPotentRPC/rgpot/tree/3.0.0) - 2026-07-26
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   rgpot
-  VERSION 3.0.0
+  VERSION 3.0.1
   DESCRIPTION "Cpp core for potential energy surface functionality"
   HOMEPAGE_URL "https://github.com/OmniPotentRPC/rgpot"
   LANGUAGES C CXX)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rgpot-core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'rgpot',
     'cpp',
-    version: '3.0.0',
+    version: '3.0.1',
     default_options: ['warning_level=2', 'cpp_std=c++20'],
 )
 # IMPORTANT!! warning_level=3 passes -fimplicit-none

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "RPC based core for potential energy surface functionality."
 name = "rgpot"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "3.0.0"
+version = "3.0.1"
 
 [feature.cigen.tasks]
 # Export every ci/gha/*.ncl workflow (shared pins/steps in ci/gha/lib/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rgpot"
-version = "3.0.0"
+version = "3.0.1"
 description = "Potential energy surfaces for atomistic simulation (LJ + Metatomic multi-ABI dlopen; nanobind abi3)"
 readme = "README.md"
 license = { text = "MIT" }
@@ -70,6 +70,13 @@ setup = [
   "-Dwith_rpc_client_only=false",
   "-Dwith_tests=false",
   "-Dwith_examples=false",
+  # The eight Fortran 2018 kernels (SW, EDIP, Lenosky, Tersoff, EAM-Al,
+  # FeHe, CuH2, TIP4P-H). Without this the wheel ships a librgpot with no
+  # Fortran-backed potentials at all -- the pots this library exists to
+  # host. Needs a Fortran compiler in the wheel build environment; the
+  # repair step vendors libgfortran into the wheel like any other
+  # dependency.
+  "-Dwith_fortran_pots=enabled",
   "-Dwith_metatomic=true",
   "-Dwith_xtb=false",
   "-Dwith_tblite=false",
@@ -84,3 +91,14 @@ dist = ["--include-subprojects"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+
+[tool.cibuildwheel]
+# manylinux images carry gcc/g++ but not gfortran, and the Fortran kernels
+# are part of the library's point.
+build-frontend = "build"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y gcc-gfortran || dnf install -y gcc-gfortran"
+
+[tool.cibuildwheel.macos]
+before-all = "brew list gcc >/dev/null 2>&1 || brew install gcc"

--- a/rgpot-core/Cargo.toml
+++ b/rgpot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgpot-core"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 description = "Core Rust library for rgpot: RPC-based potential energy surface calculations"
 license = "MIT"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 name = "rgpot"
-version = "3.0.0"
+version = "3.0.1"
 directory = "docs/newsfragments"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
`[tool.meson-python.args]` never passed `-Dwith_fortran_pots`, so the wheel -- the artifact most users install -- shipped a `librgpot` containing none of SW, EDIP, Lenosky, Tersoff, EAM-Al, FeHe, CuH2, or TIP4P-H. The release those kernels landed in would have published without them.

Adds the option to the wheel args and a cibuildwheel configuration that installs a Fortran compiler in the build image; the repair step vendors `libgfortran` like any other dependency.

Cut as 3.0.1 rather than rebuilding 3.0.0, so the tag keeps describing the artifact.