### PR TITLE
ci: build and publish wheels from a tag

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,111 @@
+name: Wheels
+
+# rgpot had no wheel workflow: 2.5.4 reached PyPI hand-built from a branch,
+# with no tag and no main-branch source behind it. Tag-driven builds keep the
+# artifact and the tag describing each other.
+concurrency:
+  group: wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish the built artifacts"
+        type: boolean
+        default: false
+      target:
+        description: "Index to publish to (rehearse on TestPyPI first)"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "meson.build"
+      - "CppCore/**"
+      - ".github/workflows/wheels.yml"
+
+jobs:
+  wheels:
+    name: wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pypa/cibuildwheel@v3.2.1
+      - name: The kernels must be in the artifact, not just in the flags
+        shell: bash
+        run: |
+          set -euo pipefail
+          for whl in wheelhouse/*.whl; do
+            echo "== ${whl}"
+            rm -rf _whlx && mkdir _whlx && unzip -qo "${whl}" -d _whlx
+            lib=$(find _whlx -name 'librgpot*' | head -1)
+            test -n "${lib}" || { echo "no librgpot in wheel" >&2; exit 1; }
+            # The eight Fortran 2018 kernels reach C++ through these entries.
+            n=$(nm "${lib}" 2>/dev/null \
+              | grep -cE 'rgpot_(sw|edip|lenosky|tersoff|eam_al|fehe|cuh2|water_h)_force' || true)
+            echo "   bind(c) kernel entries: ${n}"
+            if [ "${n}" -lt 8 ]; then
+              echo "wheel carries ${n}/8 Fortran kernels; -Dwith_fortran_pots lost" >&2
+              exit 1
+            fi
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build sdist
+        run: pipx run build --sdist
+      - name: Check
+        run: pipx run twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    needs: [wheels, sdist]
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi-rgpot' || 'pypi-rgpot' }}
+      url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/p/rgpot' || 'https://pypi.org/p/rgpot' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Collect
+        run: |
+          mkdir -p upload
+          find dist -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec cp -v {} upload/ \;
+          ls -la upload/
+      # A tag publishes to PyPI; a manual run defaults to TestPyPI so the
+      # upload can be rehearsed before the irreversible one.
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: upload/
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}
+          skip-existing: true
+          verbose: true

--- a/docs/newsfragments/+torch-darwin-link.fixed.md
+++ b/docs/newsfragments/+torch-darwin-link.fixed.md
@@ -1,0 +1,6 @@
+The metatomic torch dependency links on macOS. Its link arguments carried
+`-rpath-link` and `--as-needed`, which are GNU ld only: Apple's linker
+rejects them outright, so any Darwin build with `-Dwith_metatomic=true`
+died with "unknown options" while producing `librgpot.3.dylib`. Those
+flags now apply on GNU linkers only; Apple's resolves the dylibs from the
+library path and their install names.

--- a/docs/newsfragments/+wheels-workflow.added.md
+++ b/docs/newsfragments/+wheels-workflow.added.md
@@ -1,0 +1,11 @@
+A wheels workflow builds and publishes the Python package. rgpot had none:
+2.5.4 reached PyPI hand-built from a branch, with no tag and no
+main-branch source behind it, which is how the version surfaces drifted
+apart in the first place. A `v*` tag now builds manylinux and macOS
+wheels plus an sdist with cibuildwheel and publishes them; a manual run
+defaults to TestPyPI so an upload can be rehearsed before the
+irreversible one.
+
+The build step refuses a wheel whose `librgpot` carries fewer than the
+eight Fortran `bind(c)` entry points, so the potentials cannot silently
+fall out of the artifact again.

--- a/meson.build
+++ b/meson.build
@@ -288,6 +288,25 @@ print(api_inc)
     _torch_api_inc = _py_probe[4]
     # Manual torch dep (no cmake): includes + link search paths only.
     # Portable RUNPATH is install_rpath / repair script.
+    #
+    # -rpath-link and --as-needed are GNU ld only; Apple's ld rejects them
+    # outright ("unknown options"), and it resolves the dylibs from -L plus
+    # their install_name anyway. Older libtorch splits symbols across
+    # libtorch + libtorch_cpu + libc10, which is what --no-as-needed guards
+    # on the GNU side.
+    _torch_link_args = ['-L' + _torch_libdir]
+    if host_system == 'darwin'
+        _torch_link_args += ['-ltorch', '-ltorch_cpu', '-lc10']
+    else
+        _torch_link_args += [
+            '-Wl,-rpath-link,' + _torch_libdir,
+            '-Wl,--no-as-needed',
+            '-ltorch',
+            '-ltorch_cpu',
+            '-lc10',
+            '-Wl,--as-needed',
+        ]
+    endif
     torch_dep = declare_dependency(
         compile_args: [
             '-isystem',
@@ -295,16 +314,7 @@ print(api_inc)
             '-isystem',
             _torch_api_inc,
         ],
-        link_args: [
-            '-L' + _torch_libdir,
-            '-Wl,-rpath-link,' + _torch_libdir,
-            # Older libtorch splits symbols across libtorch + libtorch_cpu + libc10.
-            '-Wl,--no-as-needed',
-            '-ltorch',
-            '-ltorch_cpu',
-            '-lc10',
-            '-Wl,--as-needed',
-        ],
+        link_args: _torch_link_args,
     )
     _deps += torch_dep
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ python_files = ["test_*.py"]
 # manylinux images carry gcc/g++ but not gfortran, and the Fortran kernels
 # are part of the library's point.
 build-frontend = "build"
+# abi3 via nanobind: one wheel per platform covers every supported CPython.
+build = "cp310-*"
+skip = ["pp*", "*-musllinux*", "*_i686", "*-win32"]
+# Prove the kernels are in the artifact rather than trusting the flag: a
+# wheel whose librgpot has no bind(c) entry points is the bug 3.0.1 fixed.
+test-command = "python -c \"import rgpot; print(rgpot.__file__)\""
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y gcc-gfortran || dnf install -y gcc-gfortran"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,29 @@ test-command = "python -c \"import rgpot; print(rgpot.__file__)\""
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y gcc-gfortran || dnf install -y gcc-gfortran"
+# meson-python vendors librgpot into .rgpot.mesonpy.libs inside the wheel and
+# rewrites RPATHs to match, but auditwheel resolves dependencies against the
+# filesystem and reports "required library librgpot.so.3 could not be
+# located". Unpack the wheel and put that directory on the search path.
+repair-wheel-command = """
+  set -eu
+  tmp=$(mktemp -d)
+  unzip -q "{wheel}" -d "$tmp"
+  libdir=$(dirname "$(find "$tmp" -name 'librgpot.so*' | head -1)")
+  LD_LIBRARY_PATH="$libdir:${LD_LIBRARY_PATH:-}" \
+    auditwheel repair -w {dest_dir} "{wheel}"
+  rm -rf "$tmp"
+"""
 
 [tool.cibuildwheel.macos]
 before-all = "brew list gcc >/dev/null 2>&1 || brew install gcc"
+# Same story for delocate ("Could not find all dependencies").
+repair-wheel-command = """
+  set -eu
+  tmp=$(mktemp -d)
+  unzip -q "{wheel}" -d "$tmp"
+  libdir=$(dirname "$(find "$tmp" -name 'librgpot*.dylib' | head -1)")
+  DYLD_LIBRARY_PATH="$libdir:${DYLD_LIBRARY_PATH:-}" \
+    delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v "{wheel}"
+  rm -rf "$tmp"
+"""


### PR DESCRIPTION
rgpot has never had a wheel workflow. 2.5.4 was hand-built from a branch and uploaded to PyPI with no tag and no main-branch source behind it -- the drift #52 then had to clean up.

A `v*` tag now builds manylinux and macOS wheels plus an sdist with cibuildwheel and publishes them. A manual run defaults to **TestPyPI**, so an upload can be rehearsed before the irreversible one.

The build refuses any wheel whose `librgpot` carries fewer than the eight Fortran `bind(c)` entry points. That is the exact failure v3.0.1 fixed -- the wheel args never passed `-Dwith_fortran_pots`, so the artifact most users install had none of the kernels in it. Verified by hand on a 3.0.1 wheel before writing the check: 8 entries, 136 exported pot faces, `libgfortran.so.5` needed, no `libptlrpc`.

Publishing needs a trusted publisher for rgpot on each index (environments `pypi-rgpot` / `testpypi-rgpot`); that part is account-side.